### PR TITLE
Use -t flag (#11)

### DIFF
--- a/plugin/info.xml
+++ b/plugin/info.xml
@@ -215,5 +215,8 @@ Added Security Domain, LANG, and INFAHOME environment properties to the Validate
   	<release-note plugin-version="21">
 Added INFA HOME property to the Create Dynamic Deployment Group step.
   </release-note>
+  	<release-note plugin-version="22">
+The Roll Back Deployment Group Step properly uses the -t flag.
+  </release-note>
   </release-notes>
 </pluginInfo>

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -11,7 +11,7 @@
 -->
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <header>
-    <identifier version="21" id="com.urbancode.air.plugin.Informatica" name="Informatica"/>
+    <identifier version="22" id="com.urbancode.air.plugin.Informatica" name="Informatica"/>
     <description>
     The Informatica plugin is an automation based plugin. It is executed as part of the deployment to migrate Informatica configuration and run scripts against the Informatica server and for creating and deploying deploying groups.
     </description>

--- a/plugin/upgrade.xml
+++ b/plugin/upgrade.xml
@@ -194,4 +194,6 @@
           </migrate-properties>
       </migrate-command>
   </migrate>
+  <migrate to-version="22">
+  </migrate>
 </plugin-upgrade>

--- a/src/main/scripts/informatica_roll_back_deployment.groovy
+++ b/src/main/scripts/informatica_roll_back_deployment.groovy
@@ -41,7 +41,7 @@ if (domain) {
 else {
     script << "-h $host -o $port $LS"
 }
-script << "rollbackdeployment -p $groupname -n $numrevs $LS"
+script << "rollbackdeployment -p $groupname -t $numrevs $LS"
 script << "exit"
 
 println('script content:')


### PR DESCRIPTION
Roll Back Deployment Group step was using a -n instead of a -t flag.
Bumped version
