### PR TITLE
import objects checkbox fix

### DIFF
--- a/plugin/info.xml
+++ b/plugin/info.xml
@@ -218,5 +218,8 @@ Added INFA HOME property to the Create Dynamic Deployment Group step.
   	<release-note plugin-version="22">
 The Roll Back Deployment Group Step properly uses the -t flag.
   </release-note>
+  	<release-note plugin-version="23">
+Import Objects step no longer adds retaian generated sequence and checkin after import parameters to control file if not selected.
+  </release-note>
   </release-notes>
 </pluginInfo>

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -11,7 +11,7 @@
 -->
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <header>
-    <identifier version="22" id="com.urbancode.air.plugin.Informatica" name="Informatica"/>
+    <identifier version="23" id="com.urbancode.air.plugin.Informatica" name="Informatica"/>
     <description>
     The Informatica plugin is an automation based plugin. It is executed as part of the deployment to migrate Informatica configuration and run scripts against the Informatica server and for creating and deploying deploying groups.
     </description>

--- a/plugin/upgrade.xml
+++ b/plugin/upgrade.xml
@@ -196,4 +196,6 @@
   </migrate>
   <migrate to-version="22">
   </migrate>
+  <migrate to-version="23">
+  </migrate>
 </plugin-upgrade>

--- a/src/main/scripts/import_objects.groovy
+++ b/src/main/scripts/import_objects.groovy
@@ -42,8 +42,8 @@ final def folderMappingList = stepProps['folderMappingList'];
 final def repositoryMappingList = stepProps['repositoryMappingList'];
 final def conflictResolutionList = stepProps['conflictResolutionList'];
 final def conflictResolutionDefault = stepProps['conflictResolutionDefault'];
-final def retainGenSeq = stepProps['retainGenSeq'];
-final def checkinAfterImport = stepProps['checkinAfterImport'];
+final def retainGenSeq = Boolean.valueOf(stepProps['retainGenSeq']);
+final def checkinAfterImport = Boolean.valueOf(stepProps['checkinAfterImport']);
 
 final def inputFile = 'informatica_script.' + unique + '.in'
 final def outputFile = 'informatica_script.' + unique + '.out'


### PR DESCRIPTION
Imprt objectes step should no longer include retainGenSeq and checkinAfterImport in control file when not checked.