### PR TITLE
Change import_objects to generate a BASH script instead of pmrep command file

### DIFF
--- a/plugin/info.xml
+++ b/plugin/info.xml
@@ -239,5 +239,8 @@ Added Folder Migration and Validate Folder Migration steps.
     <release-note plugin-version="28">
 Added a new step - "Deploy Multiple Deployment Groups"
     </release-note>
+    <release-note plugin-version="29">
+Modified import_objects.groovy to run pmrep commands one at a time in a bash script, instead of passing pmrep a command file.
+    </release-note>
   </release-notes>
 </pluginInfo>

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -11,7 +11,7 @@
 -->
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <header>
-    <identifier version="28" id="com.urbancode.air.plugin.Informatica" name="Informatica"/>
+    <identifier version="29" id="com.urbancode.air.plugin.Informatica" name="Informatica"/>
     <description>
     The Informatica plugin is an automation based plugin. It is executed as part of the deployment to migrate Informatica configuration and run scripts against the Informatica server and for creating and deploying deploying groups.
     </description>

--- a/plugin/upgrade.xml
+++ b/plugin/upgrade.xml
@@ -252,4 +252,6 @@
       <migrate-command name="Deploy Multiple Deployment Groups">
       </migrate-command>
   </migrate>
+  <migrate to-version="29">
+  </migrate>
 </plugin-upgrade>

--- a/src/main/scripts/import_objects.groovy
+++ b/src/main/scripts/import_objects.groovy
@@ -312,12 +312,7 @@ else {
         process.getOutputStream().close() // close stdin
         process.waitFor()
 
-        if (!lastLine || !lastLine.trim().equalsIgnoreCase("exit")) {
-            exitCode = 1
-        }
-        else {
-            exitCode = process.exitValue()
-        }
+        exitCode = process.exitValue();
     }
     catch (Exception ex) {
         println "[Error] Please review the output log and stack trace for information on the error."


### PR DESCRIPTION
We were running into issues with pmrep failing when importing a large amount of objects.  According to the documentation at https://kb.informatica.com/proddocs/Product%20Documentation/4/IN_961HF3_CommandReference_en.pdf it's best to do a series of individual pmrep commands in command line mode instead.  So I modified import_objects.groovy to generate a shell script which begins with a pmrep connect command followed by a series of pmrep commands for each ObjectImport.